### PR TITLE
Change: Link to existing team in request reply message

### DIFF
--- a/templates/reply_request_translator_pending.md
+++ b/templates/reply_request_translator_pending.md
@@ -7,7 +7,7 @@ Till that time, please sit tight.
 
 _For the Core Developers_
 
-User @$USER$ is requesting access to language __$REQUEST_VALUE$__.
+User @$USER$ is requesting access to language [__$REQUEST_VALUE$__](https://github.com/orgs/OpenTTD/teams/$REQUEST_VALUE$).
 
 Please reply with either `/approve` or `/deny` in the first line of your comment to process this request.
 If you `/deny`, please be so kind to leave a reason why.


### PR DESCRIPTION
Thought it might be useful to link to the existing translator team, to evaluate the existing team members and whether it's worth mentioning that it's an empty or very full team in the approval message