### PR TITLE
Change: [GitHub] switch default branch to "main"

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,10 +3,10 @@ name: Testing
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   flake8:


### PR DESCRIPTION
This PR currently fails to run the checks, as the default branch isn't renamed yet. After this is done, this PR will be retriggered, and merged.